### PR TITLE
Adding FID statistics calculation as an option (can now do "train", "eval", or "fid_stats")

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -68,7 +68,7 @@ def central_crop(image, size):
   return tf.image.crop_to_bounding_box(image, top, left, size, size)
 
 
-def get_dataset(config, additional_dim=None, uniform_dequantization=False, evaluation=False):
+def get_dataset(config, additional_dim=None, uniform_dequantization=False, evaluation=False, drop_remainder=True):
   """Create data loaders for training and evaluation.
 
   Args:
@@ -198,7 +198,7 @@ def get_dataset(config, additional_dim=None, uniform_dequantization=False, evalu
     ds = ds.shuffle(shuffle_buffer_size)
     ds = ds.map(preprocess_fn, num_parallel_calls=tf.data.experimental.AUTOTUNE)
     for batch_size in reversed(batch_dims):
-      ds = ds.batch(batch_size, drop_remainder=True)
+      ds = ds.batch(batch_size, drop_remainder=drop_remainder)
     return ds.prefetch(prefetch_size)
 
   train_ds = create_dataset(dataset_builder, train_split_name)

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ FLAGS = flags.FLAGS
 config_flags.DEFINE_config_file(
   "config", None, "Training configuration.", lock_config=True)
 flags.DEFINE_string("workdir", None, "Work directory.")
-flags.DEFINE_enum("mode", None, ["train", "eval"], "Running mode: train or eval")
+flags.DEFINE_enum("mode", None, ["train", "eval","fid_stats"], "Running mode: train or eval or fid_stats")
 flags.DEFINE_string("eval_folder", "eval",
                     "The folder name for storing evaluation results")
 flags.mark_flags_as_required(["workdir", "config", "mode"])
@@ -58,6 +58,9 @@ def main(argv):
   elif FLAGS.mode == "eval":
     # Run the evaluation pipeline
     run_lib.evaluate(FLAGS.config, FLAGS.workdir, FLAGS.eval_folder)
+  elif FLAGS.mode == "fid_stats":
+    # Calculate the FID statistics
+    run_lib.fid_stats(FLAGS.config, FLAGS.fid_folder)
   else:
     raise ValueError(f"Mode {FLAGS.mode} not recognized.")
 

--- a/main.py
+++ b/main.py
@@ -31,6 +31,8 @@ flags.DEFINE_string("workdir", None, "Work directory.")
 flags.DEFINE_enum("mode", None, ["train", "eval","fid_stats"], "Running mode: train or eval or fid_stats")
 flags.DEFINE_string("eval_folder", "eval",
                     "The folder name for storing evaluation results")
+flags.DEFINE_string("fid_folder", "assets/stats",
+                    "The folder name for storing FID statistics")
 flags.mark_flags_as_required(["workdir", "config", "mode"])
 
 

--- a/run_lib.py
+++ b/run_lib.py
@@ -583,16 +583,14 @@ def evaluate(config,
 
 # Create FID stats by looping through the whole data
 def fid_stats(config,
-             fid_folder="assets/stats"):
+             fid_dir="assets/stats"):
   """Evaluate trained models.
 
   Args:
     config: Configuration to use.
-    fid_folder: The subfolder for storing fid statistics. 
+    fid_dir: The subfolder for storing fid statistics. 
   """
   # Create directory to eval_folder
-  #fid_dir = os.path.join(workdir, fid_folder)
-  fid_dir = fid_folder
   tf.io.gfile.makedirs(fid_dir)
 
   # Build data pipeline

--- a/run_lib.py
+++ b/run_lib.py
@@ -602,12 +602,6 @@ def fid_stats(config,
 
   # Create data normalizer and its inverse
   scaler = datasets.get_data_scaler(config)
-  inverse_scaler = datasets.get_data_inverse_scaler(config)
-  try: # Set the number of classes if info exists
-    config.model.num_classes = dataset_builder.info.features['label'].num_classes
-  except:
-    config.model.num_classes = 1
-  assert not config.model.class_conditional or (config.model.class_conditional and config.model.num_classes > 1)
 
   # Use inceptionV3 for images with resolution higher than 256.
   inceptionv3 = config.data.image_size >= 256


### PR DESCRIPTION
With these small changes, you can get the fid statistics by running with --mode "fid_stats". It loops through the dataset for 1 epoch and extract the FID statistics. That makes it easier to add new datasets.

The only issue is that I am not getting the same FID when evaluating a model on the google drive FID statistics as opposed to the one made by this new mode. Can you verify that my implementation is correct? 

I could be misusing the scaler or inverse scaler.